### PR TITLE
Fixed divmod to return tuple instead of array.

### DIFF
--- a/src/datetime2human.nim
+++ b/src/datetime2human.nim
@@ -9,8 +9,8 @@ type HumanTimes* = tuple[
   human: string, short: string, iso: string, units: HumanFriendlyTimeUnits] ## Tuple of Human Friendly Time Units as strings.
 
 
-template divmod(a, b: SomeInteger): array[2, int] =
-  [int(a / b), int(a mod b)]
+template divmod(a, b: SomeInteger): (int, int) =
+  (int(a / b), int(a mod b))
 
 func datetime2human*(datetimeObj: DateTime, isoSep: char = ' ', lower = false): HumanTimes =
   ## Calculate date & time, with precision from seconds to millenniums.


### PR DESCRIPTION
nim 2.0 results with error

```
datetime2human.nim(19, 24) Error: type mismatch: got 'array[0..1, int]' for '[int(int(toUnix(toTime(datetimeObj))) / 60),
 int(int(toUnix(toTime(datetimeObj))) mod 60)]' but expected 'tuple'
```

(minutes, seconds) = divmod( ... ) expected tuple assignment.